### PR TITLE
udp options: Add a --nocrc flag which turns off CRC on inbound UDP

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -884,24 +884,26 @@ if __name__ == '__main__':
 
     load_module('link', quiet=True)
 
+    check_crc = not opts.nocrc
+
     # open master link
     for mdev in opts.master:
-        if not mpstate.module('link').link_add(mdev):
+        if not mpstate.module('link').link_add(mdev, check_crc=check_crc):
             sys.exit(1)
 
     if not opts.master and len(serial_list) == 1:
           print("Connecting to %s" % serial_list[0])
-          mpstate.module('link').link_add(serial_list[0].device)
+          mpstate.module('link').link_add(serial_list[0].device, check_crc=check_crc)
 
     # log all packets from the master, for later replay
     open_logs()
 
     # open any mavlink output ports
     for port in opts.output:
-        mpstate.mav_outputs.append(mavutil.mavlink_connection(port, baud=int(opts.baudrate), input=False))
+        mpstate.mav_outputs.append(mavutil.mavlink_connection(port, baud=int(opts.baudrate), input=False, check_crc=check_crc))
 
     if opts.sitl:
-        mpstate.sitl_output = mavutil.mavudp(opts.sitl, input=False, check_crc=not opts.nocrc)
+        mpstate.sitl_output = mavutil.mavudp(opts.sitl, input=False, check_crc=check_crc)
 
     mpstate.settings.streamrate = opts.streamrate
     mpstate.settings.streamrate2 = opts.streamrate

--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -818,6 +818,7 @@ if __name__ == '__main__':
     parser.add_option("--mav09", action='store_true', default=False, help="Use MAVLink protocol 0.9")
     parser.add_option("--auto-protocol", action='store_true', default=False, help="Auto detect MAVLink protocol version")
     parser.add_option("--nowait", action='store_true', default=False, help="don't wait for HEARTBEAT on startup")
+    parser.add_option("--nocrc", action='store_true', default=False, help="don't check CRCs on UDP receive")
     parser.add_option("-c", "--continue", dest='continue_mode', action='store_true', default=False, help="continue logs")
     parser.add_option("--dialect",  default="ardupilotmega", help="MAVLink dialect")
     parser.add_option("--rtscts",  action='store_true', help="enable hardware RTS/CTS flow control")
@@ -900,7 +901,7 @@ if __name__ == '__main__':
         mpstate.mav_outputs.append(mavutil.mavlink_connection(port, baud=int(opts.baudrate), input=False))
 
     if opts.sitl:
-        mpstate.sitl_output = mavutil.mavudp(opts.sitl, input=False)
+        mpstate.sitl_output = mavutil.mavudp(opts.sitl, input=False, check_crc=not opts.nocrc)
 
     mpstate.settings.streamrate = opts.streamrate
     mpstate.settings.streamrate2 = opts.streamrate

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -104,10 +104,10 @@ class LinkModule(mp_module.MPModule):
             conn = self.mpstate.mav_master[i]
             print("%u: %s" % (i, conn.address))
 
-    def link_add(self, device):
+    def link_add(self, device, check_crc=True):
         '''add new link'''
         try:
-            conn = mavutil.mavlink_connection(device, autoreconnect=True, baud=self.settings.baudrate)
+            conn = mavutil.mavlink_connection(device, autoreconnect=True, baud=self.settings.baudrate, check_crc=check_crc)
         except Exception as msg:
             print("Failed to connect to %s : %s" % (device, msg))
             return False


### PR DESCRIPTION
Useful for low end CPUs to not spend so much time in mavproxy.

Needs associated changes in pymavlink