### PR TITLE
Add missing word in docs for 'time' command.

### DIFF
--- a/system.html
+++ b/system.html
@@ -41,7 +41,7 @@
           rc all -1</code></p>
           
           <h4>time</h4>
-          <p>Displays the current on the autopilot, if supported. The time in the brackets is the ground station time.</p>
+          <p>Displays the current time from the autopilot, if supported. The time in brackets is the ground station time.</p>
 
           <h4>link</h4>
           <p>Displays the telemetry link(s) status.</p>


### PR DESCRIPTION
Clarify the description of a command.