### PR TITLE
modules: added a new joystick

### DIFF
--- a/MAVProxy/modules/mavproxy_joystick.py
+++ b/MAVProxy/modules/mavproxy_joystick.py
@@ -32,6 +32,20 @@ joymap = {
      (2, 500, 1500),
      (5, 500, 1500)],
 
+    '*SAILI Simulator*':
+    # Same as above but is reporting a different name
+    # http://www.hobbyking.com/hobbyking/store/__13597__USB_Simulator_Cable_XTR_AeroFly_FMS.html
+    # has 4 usable axes. The last 4 are binary switches and not PWM outputs.
+    # Axis, Scaling Number, 
+    [(0, 500, 1500),
+     (3, 500, 1500),
+     (1, 500, 1500),
+     (2, 500, 1500),
+     (4, 500, 1500),
+     (5, 500, 1500),
+     (6, 500, 1500),
+     (7, 500, 1500)],
+
     'Sony PLAYSTATION(R)3 Controller':
     # only 4 axes usable. This assumes mode 1
     [(2, 500,  1500),


### PR DESCRIPTION
Added support for this joystick simulator cable
http://www.hobbyking.com/hobbyking/store/__13597__USB_Simulator_Cable_XTR_AeroFly_FMS.html
Support had already been added but it looks like the hardware has changed internally thus requiring this change.