### PR TITLE
Module Handling: Ensure the user gets a useful debug trace if loading fails

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -267,9 +267,8 @@ def load_module(modname, quiet=False):
                 break
         except ImportError as msg:
             ex = msg
-            if mpstate.settings.moddebug > 1:
-                import traceback
-                print(traceback.format_exc())
+            import traceback
+            print(traceback.format_exc())
     print("Failed to load module: %s" % ex)
     return False
 


### PR DESCRIPTION
If a not all dependencies is not installed (such as python-opencv), module loading will fail without a detailed error message. This patch forces MAVProxy to print out the debug trace of why module loading failed, so the user can quickly see if it's because of a dependency. Thanks for @jamiereid and @devdsp for figuring out this issue.  