### PR TITLE
fix broken install - now needs mavlink 1.1.50 or later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ on how to use MAVProxy.''',
       # as that breaks the pip install. It seems that pip is not smart enough to
       # use the system versions of these dependencies, so it tries to download and install
       # large numbers of modules like numpy etc which may be already installed
-      install_requires=['pymavlink>=1.1.2',
+      install_requires=['pymavlink>=1.1.50',
                         'pyserial'],
       scripts=['MAVProxy/mavproxy.py', 'MAVProxy/tools/mavflightview.py',
                'MAVProxy/modules/mavproxy_map/mp_slipmap.py',


### PR DESCRIPTION
@tridge - while going through my ELC slides I noticed a breakage for
virgin installs on linux hosts. mavproxy_link.py now references
MAV_COMP_ID_GIMBAL which was only added to the mavlink lib recently.
If the user had an old pymavlink 1.1.2 it would fail to run mavproxy.

MAV> Exception in thread main_loop:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/bin/mavproxy.py", line 676, in main_loop
    master.wait_heartbeat()
  File "/usr/local/lib/python2.7/dist-packages/pymavlink/mavutil.py", line 331, in wait_heartbeat
    return self.recv_match(type='HEARTBEAT', blocking=blocking)
  File "/usr/local/lib/python2.7/dist-packages/pymavlink/mavutil.py", line 296, in recv_match
    m = self.recv_msg()
  File "/usr/local/lib/python2.7/dist-packages/pymavlink/mavutil.py", line 791, in recv_msg
    msg = self.mav.parse_buffer(s)
  File "/usr/local/lib/python2.7/dist-packages/pymavlink/dialects/v10/ardupilotmega.py", line 3488, in parse_buffer
    m = self.parse_char(s)
  File "/usr/local/lib/python2.7/dist-packages/pymavlink/dialects/v10/ardupilotmega.py", line 3482, in parse_char
    self.callback(m, *self.callback_args, **self.callback_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/MAVProxy/modules/mavproxy_link.py", line 261, in master_callback
    if m.get_srcComponent() == mavutil.mavlink.MAV_COMP_ID_GIMBAL and m.get_type() == 'HEARTBEAT':
AttributeError: 'module' object has no attribute 'MAV_COMP_ID_GIMBAL'