### PR TITLE
Optionally visualize loiter radii as cirlces on the map.

### DIFF
--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -46,7 +46,8 @@ class MapModule(mp_module.MPModule):
               ('showsimpos', int, 0),
               ('showahrs2pos', int, 0),
               ('brightness', float, 1),
-              ('rallycircle', bool, False)])
+              ('rallycircle', bool, False),
+              ('loitercircle',bool, False)])
         service='OviHybrid'
         if 'MAP_SERVICE' in os.environ:
             service = os.environ['MAP_SERVICE']
@@ -124,6 +125,7 @@ class MapModule(mp_module.MPModule):
                 self.mpstate.map.add_object(mp_slipmap.SlipPolygon('mission %u' % i, p,
                                                                    layer='Mission', linewidth=2, colour=(255,255,255),
                                                                    popup_menu=popup))
+        loiter_rad = self.get_mav_param('WP_LOITER_RAD')
         labeled_wps = {}
         for i in range(len(self.mission_list)):
             next_list = self.mission_list[i]
@@ -131,9 +133,13 @@ class MapModule(mp_module.MPModule):
                 #label already printed for this wp?
                 if (next_list[j] not in labeled_wps):
                     self.mpstate.map.add_object(mp_slipmap.SlipLabel(
-                        'miss_cmd %u/%u' % (i,j), polygons[i][j], str(next_list[j]), 'Mission', colour=(0,255,255)))  
+                        'miss_cmd %u/%u' % (i,j), polygons[i][j], str(next_list[j]), 'Mission', colour=(0,255,255)))
+
+                    if (self.module('wp').wploader.wp_is_loiter(next_list[j])
+                        and self.map_settings.loitercircle):
+                        self.mpstate.map.add_object(mp_slipmap.SlipCircle('Loiter Cirlce %u' % (next_list[j] + 1), 'LoiterCircles', polygons[i][j], abs(loiter_rad), (255, 255, 255), 2))
+
                     labeled_wps[next_list[j]] = (i,j)
-                    
 
     def display_fence(self):
         '''display the fence'''

--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -177,6 +177,8 @@ class ParamState:
             if (param.upper() == "WP_LOITER_RAD" or param.upper() == "LAND_BREAK_PATH"):
                 #need to redraw rally points
                 mpstate.module('rally').rallyloader.last_change = time.time()
+                #need to redraw loiter points
+                mpstate.module('wp').wploader.last_change = time.time()
 
         elif args[0] == "load":
             if len(args) < 2:


### PR DESCRIPTION
Added a map setting "loitercircle" that will show all loiter waypoints in the mission as circles with radius WP_LOITER_RAD rather than points.

Depends on:
https://github.com/mavlink/mavlink/pull/365
