### PR TITLE
DGPS: Fix for receiving UDP injection packets

### DIFF
--- a/MAVProxy/modules/mavproxy_DGPS.py
+++ b/MAVProxy/modules/mavproxy_DGPS.py
@@ -16,6 +16,7 @@ class DGPSModule(mp_module.MPModule):
         self.port.bind(("127.0.0.1", self.portnum))
         mavutil.set_close_on_exec(self.port.fileno())
         self.port.setblocking(0)
+        print "Listening for DGPS packets on UDP://%s:%s" % ("127.0.0.1", self.portnum)
 
     def idle_task(self):
         '''called in idle time'''
@@ -28,9 +29,16 @@ class DGPSModule(mp_module.MPModule):
         if len(data) > 110:
             print("DGPS data too large: %u bytes" % len(data))
             return
-        self.master.mav.gps_inject_data_send(self.target_system,
-                                                  self.target_component,
-                                                  len(data), data)
+        try:
+
+            self.master.mav.gps_inject_data_send(
+                self.target_system,                                  
+                self.target_component,
+                len(data), 
+                bytearray(data.ljust(110, '\0')))
+
+        except Exception,e:
+            print "DGPS Failed:", e
 
 def init(mpstate):
     '''initialise module'''

--- a/MAVProxy/modules/mavproxy_checklist.py
+++ b/MAVProxy/modules/mavproxy_checklist.py
@@ -40,7 +40,7 @@ class ChecklistModule(mp_module.MPModule):
 
         if type in [ 'GPS_RAW', 'GPS_RAW_INT' ]:
             '''beforeEngineList - GPS lock'''
-            if ((msg.fix_type == 3 and master.mavlink10()) or
+            if ((msg.fix_type >= 3 and master.mavlink10()) or
                 (msg.fix_type == 2 and not master.mavlink10())):
                 self.checklist.set_check("GPS lock", 1)
             else:


### PR DESCRIPTION
This is a bugfix for listening to DGPS packets on UDP, and sending a gps_inject_data mavlink message to the quad.