### PR TITLE
WXConsole: Fixed disappearing-menu problem when loading some modules

### DIFF
--- a/MAVProxy/modules/lib/wxconsole.py
+++ b/MAVProxy/modules/lib/wxconsole.py
@@ -177,9 +177,11 @@ class ConsoleFrame(wx.Frame):
                     self.control.SetDefaultStyle(oldstyle)
                 self.pending = []
             elif isinstance(obj, mp_menu.MPMenuTop):
-                self.menu = obj
-                self.SetMenuBar(self.menu.wx_menu())
-                self.Bind(wx.EVT_MENU, self.on_menu)
+                if obj is not None:
+                    self.SetMenuBar(None)
+                    self.menu = obj
+                    self.SetMenuBar(self.menu.wx_menu())
+                    self.Bind(wx.EVT_MENU, self.on_menu)
                 self.Refresh()
                 self.Update()
 


### PR DESCRIPTION
When modules-containing-menus are loaded, the wxconsole menu will disappear due to reassigning the self.menu object whilst it's still being used. Solution is to set the set the menu to "None" whilst updating the self.menu  